### PR TITLE
Map loading/saving

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ target_include_directories(bin_vocabulary PUBLIC
 target_link_libraries(bin_vocabulary DBoW2 ${OpenCV_LIBS})
 
 # Convert txt vocabulary to binary
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
 if(WIN32)
     add_custom_target(ORBvoc.bin ALL
         COMMAND ${CMAKE_COMMAND} -E tar "xfz" "ORBvoc.txt.tar.gz"

--- a/include/System.h
+++ b/include/System.h
@@ -71,7 +71,8 @@ public:
     //Initialize the SLAM system without using settings file. It launches the Local Mapping, Loop Closing and Viewer threads.
     System(ORBVocabulary *voc, const Camera& camParams, const OrbParameters& orbParams,
            const ViewerParameters& viewerParams,
-           const eSensor sensor, const bool bUseViewer = true);
+           const eSensor sensor, const bool bUseViewer = true,
+           const bool saveMap = false, std::string const& mapFile = "");
 
 
     void setCameraParameters(const Camera& camParams);

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -62,7 +62,7 @@ public:
 
     Tracking(System* pSys, ORBVocabulary* pVoc, FrameDrawer* pFrameDrawer, MapDrawer* pMapDrawer, Map* pMap,
              KeyFrameDatabase* pKFDB, const Camera& camParams, const OrbParameters& orbParams,
-             const int sensor);
+             const int sensor, bool bReuseMap = false);
 
     void setOrbParameters(const OrbParameters& orbParams);
 

--- a/include/Viewer.h
+++ b/include/Viewer.h
@@ -43,7 +43,7 @@ class ORB_SLAM2_EXPORT Viewer
 {
 public:
     Viewer(System* pSystem, FrameDrawer* pFrameDrawer, MapDrawer* pMapDrawer, Tracking *pTracking,
-           const Camera& camParams, const ViewerParameters& viewerParams);
+           const Camera& camParams, const ViewerParameters& viewerParams, bool bReuseMap);
 
     Viewer(System* pSystem, FrameDrawer* pFrameDrawer, MapDrawer* pMapDrawer, Tracking *pTracking, const string &strSettingPath, bool mbReuseMap);
 

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -152,7 +152,7 @@ Tracking::Tracking(System *pSys, ORBVocabulary* pVoc, FrameDrawer *pFrameDrawer,
 
 Tracking::Tracking(System *pSys, ORBVocabulary *pVoc, FrameDrawer *pFrameDrawer, MapDrawer *pMapDrawer,
                    Map *pMap, KeyFrameDatabase *pKFDB, const Camera &camParams, const OrbParameters &orbParams,
-                   const int sensor):
+                   const int sensor, bool bReuseMap):
     mState(NO_IMAGES_YET), mSensor(sensor), mbOnlyTracking(false), mbVO(false), mpORBVocabulary(pVoc),
     mpKeyFrameDB(pKFDB), mpInitializer(static_cast<Initializer*>(NULL)), mpSystem(pSys),
     mpFrameDrawer(pFrameDrawer), mpMapDrawer(pMapDrawer), mpMap(pMap), mnLastRelocFrameId(0)
@@ -253,6 +253,8 @@ Tracking::Tracking(System *pSys, ORBVocabulary *pVoc, FrameDrawer *pFrameDrawer,
         else
             mDepthMapFactor = 1.0f/mDepthMapFactor;
     }
+    if (bReuseMap)
+        mState = LOST;
 }
 
 void Tracking::setOrbParameters(const OrbParameters &orbParams)

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -54,9 +54,11 @@ Viewer::Viewer(System* pSystem, FrameDrawer *pFrameDrawer, MapDrawer *pMapDrawer
 }
 
 Viewer::Viewer(System *pSystem, FrameDrawer *pFrameDrawer, MapDrawer *pMapDrawer,
-               Tracking *pTracking, const Camera &camParams, const ViewerParameters &viewerParams):
+               Tracking *pTracking, const Camera &camParams, const ViewerParameters &viewerParams,
+               bool bReuseMap):
     mpSystem(pSystem), mpFrameDrawer(pFrameDrawer),mpMapDrawer(pMapDrawer), mpTracker(pTracking),
-    mbFinishRequested(false), mbFinished(true), mbStopped(false), mbStopRequested(false)
+    mbFinishRequested(false), mbFinished(true), mbStopped(false), mbStopRequested(false),
+    mbReuseMap(bReuseMap)
 {
 
     float fps = camParams.m_fps;


### PR DESCRIPTION
This PR makes it possible to use the load/save feature with the constructor using camera parameters. It also fixes the binary vocabulary file being generated twice by removing the dependency between the `all` and `install` targets, so if you ever build this by hand, please double check that your build completed successfully before attempting to install.